### PR TITLE
fix: 🐛  updated url regex for raising requests and allowed only signedin users to raise a request

### DIFF
--- a/src/Courses/index.tsx
+++ b/src/Courses/index.tsx
@@ -804,22 +804,37 @@ export function RequestCourseInModal({
   );
 }
 
-const urlRegex = /^(https?:\/\/)?([\da-z.-]+)\.([a-z.]{2,6})([/\w .-]*)*\/?$/;
-function RequestCourseForm({ close }: { close?: () => void }) {
+const urlRegex =
+  /(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})/gi;
+function RequestCourseForm({
+  user,
+  close,
+}: {
+  user: User;
+  close?: () => void;
+}) {
   const addRequest = useAddRequest();
   return (
     <Formik
       initialValues={{ course_url: "" as string }}
       onSubmit={formikOnSubmitWithErrorHandling(async (values) => {
-        await addRequest(values.course_url);
+        await addRequest({
+          courseUrl: values.course_url,
+          user: {
+            uid: user.uid,
+            name: user?.displayName || "",
+            email: user?.email || "",
+            photo: user?.photoURL,
+          },
+        });
         close?.();
         toast.success("We have raised a request for this course!");
       })}
       validationSchema={Validator.object({}).shape({
         course_url: Validator.string()
           .min(10)
-          .max(200)
-          .matches(urlRegex, "Please enter a valid url/course link.")
+          .max(500)
+          .matches(urlRegex, "Please enter a valid url/link for the course!")
           .required(
             "Please enter this course URL that you would want to add on our platform!"
           ),
@@ -836,6 +851,7 @@ function RequestCourseForm({ close }: { close?: () => void }) {
             <FormField
               name="course_url"
               label="Course URL"
+              pattern={`${urlRegex}`}
               placeholder="Eg. https://www.scaler.com/courses/data-structures-and-algorithms/"
               required
             />

--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -1,3 +1,7 @@
+import { useMemo } from "react";
+import { signOut } from "firebase/auth";
+import { useAuth, useUser } from "reactfire";
+import { Link, Outlet, useLocation } from "react-router-dom";
 import config from "./config";
 import {
   Box,
@@ -14,12 +18,10 @@ import {
   MenuItem,
 } from "./components";
 import { ArrowRightIcon, LogoutIcon } from "./components/Icons";
-import { Link, Outlet, useLocation } from "react-router-dom";
+
 import { LoginOrRegisterInModal } from "./Auth";
-import { useAuth, useUser } from "reactfire";
 import { getInitials } from "./utils";
-import { signOut } from "firebase/auth";
-import { useMemo } from "react";
+
 import { USER_PERMISSIONS, checkIfUserCan, useProfile } from "./data";
 import { RequestCourseInModal } from "./Courses";
 
@@ -54,21 +56,23 @@ export function Navigation() {
               justifyContent="end"
               alignItems="center"
             >
-              <Box className="hidden md:block">
-                <RequestCourseInModal>
-                  {({ add }) => (
-                    <Box cursor="pointer" onClick={add}>
-                      <Text
-                        color="textLow"
-                        className="underline underline-offset-2"
-                        fontSize="b3"
-                      >
-                        Request a course?
-                      </Text>
-                    </Box>
-                  )}
-                </RequestCourseInModal>
-              </Box>
+              {user?.uid ? (
+                <Box className="hidden md:block">
+                  <RequestCourseInModal user={user}>
+                    {({ add }) => (
+                      <Box cursor="pointer" onClick={add}>
+                        <Text
+                          color="textLow"
+                          className="underline underline-offset-2"
+                          fontSize="b3"
+                        >
+                          Request a course?
+                        </Text>
+                      </Box>
+                    )}
+                  </RequestCourseInModal>
+                </Box>
+              ) : null}
 
               {!user?.uid ? (
                 <Inline gap="4">

--- a/src/data/courses.ts
+++ b/src/data/courses.ts
@@ -67,6 +67,12 @@ export type Course = {
 export type Request = {
   id: string;
   url: string;
+  user: {
+    uid: string;
+    name: string;
+    email: string;
+    photo?: string | null;
+  };
   created_at: Timestamp;
   updated_at: Timestamp;
 };
@@ -512,15 +518,25 @@ export function useAddNewCourse() {
   );
 }
 
+type RequestPayload = {
+  courseUrl: string;
+  user: {
+    uid: string;
+    name: string;
+    email: string;
+    photo?: string | null;
+  };
+};
 export function useAddRequest() {
   const requestsCollection = useCourseRequestCollection();
   return useCallback(
-    async (courseUrl: string) => {
+    async ({ courseUrl, user }: RequestPayload) => {
       try {
         const docRef = doc(requestsCollection);
         await setDoc(docRef, {
           id: docRef.id,
           url: courseUrl,
+          user,
           updated_at: serverTimestamp(),
           created_at: serverTimestamp(),
         });


### PR DESCRIPTION
**PR Description**

This PR addresses two main issues related to URL regex validation and access control for raising requests.

**URL Regex Fix**

The previous URL regex pattern was not correctly validating certain valid URLs, particularly those containing query parameters or fragments. The regex has been updated to handle these cases, ensuring that all valid URLs are accepted when raising requests.

**User Authentication Check**

Previously, any user (authenticated or not) could raise a request. This PR introduces a check to ensure that only signed-in users can initiate a new request. This change enhances security and prevents unauthorized users from creating requests.
